### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/app/src/__tests__/project-collaboration.test.tsx
+++ b/app/src/__tests__/project-collaboration.test.tsx
@@ -93,8 +93,18 @@ const MockRepositoryLinker = () => {
     { id: '2', name: 'backend-api', url: 'https://github.com/user/backend-api' },
   ])
 
+  // Helper to check for safe URL protocols
+  const isSafeUrl = (url: string) => {
+    try {
+      const parsed = new URL(url, window.location.origin);
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    } catch {
+      return false;
+    }
+  };
+
   const linkRepository = () => {
-    if (repoUrl.trim()) {
+    if (repoUrl.trim() && isSafeUrl(repoUrl.trim())) {
       const repoName = repoUrl.split('/').pop() || 'repository'
       setLinkedRepos([...linkedRepos, {
         id: Date.now().toString(),


### PR DESCRIPTION
Potential fix for [https://github.com/FizzWizZleDazzle/Nivaro/security/code-scanning/2](https://github.com/FizzWizZleDazzle/Nivaro/security/code-scanning/2)

To fix this problem, we need to ensure that only safe URLs are used in the `href` attribute of the `<a>` tag. The best way is to validate or sanitize the user input before storing it in state or before rendering it. Specifically, we should allow only URLs that start with `http://` or `https://`, and reject or ignore any others (such as `javascript:`, `data:`, etc.). This can be done by checking the protocol of the URL before adding it to the `linkedRepos` array in the `linkRepository` function. If the URL is not safe, we can either show an error or simply not add it.

**What to change:**  
- In the `linkRepository` function (lines 96–106), before adding the new repo, check that `repoUrl` starts with `http://` or `https://`.  
- Only add the repo if the URL passes this check.  
- Optionally, show an error message if the URL is invalid (not required for the fix, but good UX).

**What is needed:**  
- A helper function to validate the URL protocol (can be defined inline in the component).
- Update the `linkRepository` function to use this validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
